### PR TITLE
Review pull request: BXMSDOC-6430 Added prereq links

### DIFF
--- a/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
+++ b/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
@@ -27,11 +27,11 @@ The build procedure creates a custom extension image that extends the existing {
 ** Docker - For installation instructions, see https://docs.docker.com/get-docker/[Get Docker].
 ** Cekit version 3.2 - For installation instructions, see https://docs.cekit.io/en/3.2.0/handbook/installation/index.html[Installation].
 ** The following libraries and extensions for Cekit. For more information, see https://docs.cekit.io/en/latest/handbook/installation/dependencies.html[Dependencies].
-*** `odcs-client`, provided by the `python3-odcs-client` package or similar package
+//*** `odcs-client`, provided by the `python3-odcs-client` package or similar package
 *** `docker`, provided by the `python3-docker` package or similar package
 *** `docker-squash`, provided by the `python3-docker-squash` package or similar package
 *** `behave`, provided by the `python3-behave` package or similar package
-*** `s2i`, provided by the `source-to-image` package or similar package. For more information, see https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html/using_red_hat_software_collections_container_images/sti[Chapter 2. Using Source-to-Image (S2I)].
+//*** `s2i`, provided by the `source-to-image` package or similar package. For more information, see https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html/using_red_hat_software_collections_container_images/sti[Chapter 2. Using Source-to-Image (S2I)].
 
 .Procedure
 . For IBM DB2, Oracle Database, or Sybase, provide the JDBC driver JAR file in a local directory.

--- a/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
+++ b/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
@@ -25,13 +25,13 @@ The build procedure creates a custom extension image that extends the existing {
 * For Oracle Database, IBM DB2, or Sybase, you downloaded the JDBC driver from the database server vendor.
 * You have installed the following required software:
 ** Docker - For installation instructions, see https://docs.docker.com/get-docker/[Get Docker].
-** Cekit version 3.2 - For installation instructions, see https://docs.cekit.io/en/latest/handbook/installation/index.html[Installation].
-** The following libraries and extensions for Cekit. For more information, see https://docs.cekit.io/en/latest/handbook/installation/dependencies.html[Dependencies]:
+** Cekit version 3.2 - For installation instructions, see https://docs.cekit.io/en/3.2.0/handbook/installation/index.html[Installation].
+** The following libraries and extensions for Cekit. For more information, see https://docs.cekit.io/en/latest/handbook/installation/dependencies.html[Dependencies].
 *** `odcs-client`, provided by the `python3-odcs-client` package or similar package
 *** `docker`, provided by the `python3-docker` package or similar package
 *** `docker-squash`, provided by the `python3-docker-squash` package or similar package
 *** `behave`, provided by the `python3-behave` package or similar package
-*** `s2i`, provided by the `source-to-image` package or similar package
+*** `s2i`, provided by the `source-to-image` package or similar package. For more information, see https://access.redhat.com/documentation/en-us/red_hat_software_collections/3/html/using_red_hat_software_collections_container_images/sti[Chapter 2. Using Source-to-Image (S2I)].
 
 .Procedure
 . For IBM DB2, Oracle Database, or Sybase, provide the JDBC driver JAR file in a local directory.

--- a/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
+++ b/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
@@ -24,9 +24,9 @@ The build procedure creates a custom extension image that extends the existing {
 * You are logged in to your OpenShift environment using the `oc` command. Your OpenShift user must have the `registry-editor` role.
 * For Oracle Database, IBM DB2, or Sybase, you downloaded the JDBC driver from the database server vendor.
 * You have installed the following required software:
-** Docker
-** Cekit version 3.2
-** The following libraries and extensions for Cekit:
+** Docker - For installation instructions, see https://docs.docker.com/get-docker/[Get Docker].
+** Cekit version 3.2 - For installation instructions, see https://docs.cekit.io/en/latest/handbook/installation/index.html[Installation].
+** The following libraries and extensions for Cekit. For more information, see https://docs.cekit.io/en/latest/handbook/installation/dependencies.html[Dependencies]:
 *** `odcs-client`, provided by the `python3-odcs-client` package or similar package
 *** `docker`, provided by the `python3-docker` package or similar package
 *** `docker-squash`, provided by the `python3-docker-squash` package or similar package

--- a/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
+++ b/doc-content/enterprise-only/openshift/externaldb-build-proc.adoc
@@ -26,7 +26,7 @@ The build procedure creates a custom extension image that extends the existing {
 * You have installed the following required software:
 ** Docker - For installation instructions, see https://docs.docker.com/get-docker/[Get Docker].
 ** Cekit version 3.2 - For installation instructions, see https://docs.cekit.io/en/3.2.0/handbook/installation/index.html[Installation].
-** The following libraries and extensions for Cekit. For more information, see https://docs.cekit.io/en/latest/handbook/installation/dependencies.html[Dependencies].
+** The following libraries and extensions for Cekit. For more information, see https://docs.cekit.io/en/3.2.0/handbook/installation/dependencies.html[Dependencies].
 //*** `odcs-client`, provided by the `python3-odcs-client` package or similar package
 *** `docker`, provided by the `python3-docker` package or similar package
 *** `docker-squash`, provided by the `python3-docker-squash` package or similar package


### PR DESCRIPTION
Added prereq installation links per DDF customer request

You have installed the following required software:

Docker - For installation instructions, see Get Docker.
Cekit version 3.2 - For installation instructions, see Installation.
The following libraries and extensions for Cekit. For more information, see Dependencies:
odcs-client, provided by the python3-odcs-client package or similar package
docker, provided by the python3-docker package or similar package
docker-squash, provided by the python3-docker-squash package or similar package
behave, provided by the python3-behave package or similar package
s2i, provided by the source-to-image package or similar package

Original jira: https://issues.redhat.com/browse/BXMSDOC-6430
Rendered output: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-6430/#externaldb-build-proc_openshift-authoring 