### PR TITLE
BXMSDOC-6427 Removed The ZIP files do not require a graphical user in…

### DIFF
--- a/doc-content/enterprise-only/installation/assembly_installing-on-eap-deployable.adoc
+++ b/doc-content/enterprise-only/installation/assembly_installing-on-eap-deployable.adoc
@@ -1,6 +1,6 @@
 [id='assembly_installing-on-eap-deployable_{context}']
 = Installing {PRODUCT} from ZIP files
-The {PRODUCT} ZIP files (one for {CENTRAL} and one for {KIE_SERVER}) do not require a graphical user interface so you can install {PRODUCT} using SSH.
+The {PRODUCT} ZIP files (one for {CENTRAL} and one for {KIE_SERVER}) do not require a graphical user interface.
 
 [NOTE]
 ====

--- a/doc-content/enterprise-only/installation/install-download-proc.adoc
+++ b/doc-content/enterprise-only/installation/install-download-proc.adoc
@@ -36,8 +36,6 @@ ifdef::PAM[]
 ** *{PRODUCT} {PRODUCT_VERSION_LONG} {CENTRAL} Deployable for EAP 7*
 (`{PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-eap7-deployable.zip`)
 ** *{PRODUCT} {PRODUCT_VERSION_LONG} Add Ons* (`{PRODUCT_FILE}-add-ons.zip`)
-+
-The ZIP files do not require a graphical user interface so you can install {PRODUCT} using SSH.
 endif::PAM[]
 
 ifdef::DM[]
@@ -52,8 +50,6 @@ ifdef::PAM[]
 * To install {KIE_SERVER} on {JWS} using the deployable ZIP files, download the following files:
 ** *{PRODUCT} {PRODUCT_VERSION_LONG} Add Ons* (`{PRODUCT_FILE}-add-ons.zip`)
 ** *{PRODUCT} {PRODUCT_VERSION_LONG} Maven Repository* (`{PRODUCT_FILE}-maven-repository.zip`)
-+
-The ZIP files do not require a graphical user interface so you can install {PRODUCT} using SSH.
 endif::PAM[]
 ifdef::DM[]
 * To install {KIE_SERVER} on {JWS} using the deployable ZIP file, download the *{PRODUCT} {PRODUCT_VERSION_LONG} Add Ons* (`{PRODUCT_FILE}-add-ons.zip`) file.
@@ -67,8 +63,6 @@ ifdef::PAM[]
 * To install {KIE_SERVER} on {TOMCAT} using the deployable ZIP files, download the following files:
 ** *{PRODUCT} {PRODUCT_VERSION_LONG} Add Ons* (`{PRODUCT_FILE}-add-ons.zip`)
 ** *{PRODUCT} {PRODUCT_VERSION_LONG} Maven Repository* (`{PRODUCT_FILE}-maven-repository.zip`)
-+
-The ZIP files do not require a graphical user interface so you can install {PRODUCT} using SSH.
 endif::PAM[]
 ifdef::DM[]
 * To install {KIE_SERVER} on {TOMCAT} using the deployable ZIP file, download the *{PRODUCT} {PRODUCT_VERSION_LONG} Add Ons* (`{PRODUCT_FILE}-add-ons.zip`) file.

--- a/doc-content/enterprise-only/installation/install-download-proc.adoc
+++ b/doc-content/enterprise-only/installation/install-download-proc.adoc
@@ -54,7 +54,7 @@ endif::PAM[]
 ifdef::DM[]
 * To install {KIE_SERVER} on {JWS} using the deployable ZIP file, download the *{PRODUCT} {PRODUCT_VERSION_LONG} Add Ons* (`{PRODUCT_FILE}-add-ons.zip`) file.
 +
-The ZIP file does not require a graphical user interface so you can install {PRODUCT} using SSH.
+The ZIP file does not require a graphical user interface.
 endif::DM[]
 endif::[]
 
@@ -66,8 +66,6 @@ ifdef::PAM[]
 endif::PAM[]
 ifdef::DM[]
 * To install {KIE_SERVER} on {TOMCAT} using the deployable ZIP file, download the *{PRODUCT} {PRODUCT_VERSION_LONG} Add Ons* (`{PRODUCT_FILE}-add-ons.zip`) file.
-+
-The ZIP file does not require a graphical user interface so you can install {PRODUCT} using SSH.
 endif::DM[]
 endif::[]
 

--- a/doc-content/enterprise-only/installation/install-options-proc.adoc
+++ b/doc-content/enterprise-only/installation/install-options-proc.adoc
@@ -10,7 +10,7 @@ Depending on your environment and project requirements, choose one of the follow
 ====
 
 * Download and run the executable JAR installer for installation on {EAP} 7.1 or {JWS} {JWS_VERSION}. The installer graphical user interface guides you through the installation process.
-* Download one of the following ZIP files. The ZIP files do not require a graphical user interface so you can install {PRODUCT} using SSH.
+* Download one of the following ZIP files.
 ** To install {PRODUCT} on {EAP} {EAP_VERSION}, download the following files:
 ifdef::DM[]
 *** `{PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-eap7-deployable.zip`

--- a/doc-content/enterprise-only/installation/install-options-proc.adoc
+++ b/doc-content/enterprise-only/installation/install-options-proc.adoc
@@ -10,7 +10,7 @@ Depending on your environment and project requirements, choose one of the follow
 ====
 
 * Download and run the executable JAR installer for installation on {EAP} 7.1 or {JWS} {JWS_VERSION}. The installer graphical user interface guides you through the installation process.
-* Download one of the following ZIP files.
+* Download one of the following ZIP files:
 ** To install {PRODUCT} on {EAP} {EAP_VERSION}, download the following files:
 ifdef::DM[]
 *** `{PRODUCT_FILE}-{URL_COMPONENT_CENTRAL}-eap7-deployable.zip`


### PR DESCRIPTION
Removed ""The ZIP files do not require a graphical user interface so you can install Red Hat Process Automation Manager using SSH." from the download steps. [~ksuta] confirmed that this statement is confusing and that the following chapters contain all necessary installation procedures. 

Original jira: https://issues.redhat.com/browse/BXMSDOC-6427
Rendered output: 
DM: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-6427DM/#install-download-proc_install-on-eap
PAM: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-6427PAM/#install-download-proc_install-on-eap