### PR TITLE
Review PR: BXMSDOC-1259 Added note detailing multiple user and group permission resolution

### DIFF
--- a/doc-content/enterprise-only/admin-and-config/business-central-settings-changing-permissions-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/business-central-settings-changing-permissions-proc.adoc
@@ -3,6 +3,7 @@
 
 You cannot change permissions for an individual user. However, you can change permissions for groups and roles. The changed permissions apply to users that have the role or belong to the group that you changed.
 
+
 .Procedure
 . In {CENTRAL}, select the *Admin* icon in the top-right corner of the screen.
 . Click *Roles* or *Groups* to open the corresponding list.
@@ -22,5 +23,7 @@ You cannot add an exception to the {CENTRAL} resource type.
 
 [NOTE]
 ====
-Any changes you make to roles or groups affect all of the users associated with that role or group.
+Any changes that you make to roles or groups affect all of the users associated with that role or group.
+
+If a user is a member of multiple groups that have the same priority and the groups have conflicting permission settings, the positive permissions override the negative permissions. For large group assignments, you can verify the permission settings in {CENTRAL} by clicking the *Admin* icon in the top-right corner, select *Users*, and view each user's group assignments and permissions.
 ====

--- a/doc-content/enterprise-only/admin-and-config/business-central-settings-changing-permissions-proc.adoc
+++ b/doc-content/enterprise-only/admin-and-config/business-central-settings-changing-permissions-proc.adoc
@@ -25,5 +25,5 @@ You cannot add an exception to the {CENTRAL} resource type.
 ====
 Any changes that you make to roles or groups affect all of the users associated with that role or group.
 
-If a user is a member of multiple groups that have the same priority and the groups have conflicting permission settings, the positive permissions override the negative permissions. For large group assignments, you can verify the permission settings in {CENTRAL} by clicking the *Admin* icon in the top-right corner, select *Users*, and view each user's group assignments and permissions.
+If a user is a member of multiple groups that have the same priority and the groups have conflicting permission settings, the positive permissions override the negative permissions. You can verify the permission settings in {CENTRAL} by clicking the *Admin* icon in the top-right corner, select *Users*, and view each user's group assignments and permissions.
 ====


### PR DESCRIPTION
Original jira: https://issues.redhat.com/browse/BXMSDOC-1259
Rendered output: http://file.rdu.redhat.com/~mhaglund/BXMSDOC-1259/#business-central-settings-changing-permissions-proc_configuring-central

Added the following to the existing note in http://file.rdu.redhat.com/~mhaglund/BXMSDOC-1259/#business-central-settings-changing-permissions-proc_configuring-central:

If a user is a member of multiple groups that have the same priority and the groups have conflicting permission settings, the positive permissions override the negative permissions. For large group assignments, you can verify the permission settings in Business Central by clicking the Admin icon in the top-right corner, select Users, and view each user’s group assignments and permissions.